### PR TITLE
minor modification to sample/download_files.sh

### DIFF
--- a/sample/download_files.sh
+++ b/sample/download_files.sh
@@ -16,7 +16,7 @@ cd data/
 tar -xf ro-en.tgz
 unzip SETIMES2.ro-en.txt.zip
 
-cat europarl-v7.ro-en.en SETIMES2.en-ro.en > corpus.en
-cat europarl-v7.ro-en.ro SETIMES2.en-ro.ro > corpus.ro
+cat europarl-v7.ro-en.en SETIMES.en-ro.en > corpus.en
+cat europarl-v7.ro-en.ro SETIMES.en-ro.ro > corpus.ro
 
 cd ..


### PR DESCRIPTION
The extracted files of **SETIMES2.ro-en.txt.zip** are named as **SETIMES.en-ro** . Not as **SETIMES2.en-ro.** 